### PR TITLE
Added fallback for rateThisApp()

### DIFF
--- a/app/src/main/java/com/userhook/UserHook.java
+++ b/app/src/main/java/com/userhook/UserHook.java
@@ -322,14 +322,24 @@ public class UserHook {
 
     public static void rateThisApp() {
 
-        Intent intent = new Intent(Intent.ACTION_VIEW);
-        intent.setData(Uri.parse("market://details?id=" + applicationContext.getPackageName()));
-        activityLifecycle.getCurrentActivity().startActivity(intent);
+        startActivityToRate();
 
         // tell User Hook that this user has rated this app
         UserHook.markAsRated();
     }
 
+    private static void startActivityToRate() {
+        Uri uri = Uri.parse("market://details?id=" + applicationContext.getPackageName());
+        Intent goToMarket = new Intent(Intent.ACTION_VIEW, uri);
+        goToMarket.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY | Intent.FLAG_ACTIVITY_MULTIPLE_TASK);
+        if (goToMarket.resolveActivity(applicationContext.getPackageManager()) != null) {
+            activityLifecycle.getCurrentActivity().startActivity(goToMarket);
+            return;
+        }
+
+        activityLifecycle.getCurrentActivity().startActivity(new Intent(Intent.ACTION_VIEW,
+                Uri.parse("http://play.google.com/store/apps/details?id=" + applicationContext.getPackageName())));
+    }
 
     public static void setFeedbackScreenTitle(String title){
         feedbackScreenTitle = title;


### PR DESCRIPTION
Currently if we don't have a store application on our phone the app will crash by trying to resolve `market://` URI.

In this PR I add a fallback to open a browser if any activity was found to manage the `market://` URI. Its avoid the crash and allow the user to rate the app.
